### PR TITLE
Use lever specific version of racer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.swp
 node_modules
+.idea/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "derby-parsing": "^0.5.0",
     "derby-templates": "^0.4.0",
     "html-util": "^0.2.1",
-    "racer": "^0.9.0",
+    "racer": "^0.9.3-lever",
     "resolve": "^1.1.6",
     "through": "^2.3.4",
     "tracks": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "derby-parsing": "^0.5.0",
     "derby-templates": "^0.4.0",
     "html-util": "^0.2.1",
-    "racer": "^0.9.3-lever",
+    "racer": "0.9.3-lever",
     "resolve": "^1.1.6",
     "through": "^2.3.4",
     "tracks": "^0.5.0"


### PR DESCRIPTION
This version of racer depends on the optimized version of sharedb which
we want to use to optimize our access control code.

This will be published as `0.9.7-lever`